### PR TITLE
fix(#11) replace import mortal by contract Mortal

### DIFF
--- a/contracts/47_array_passer.sol
+++ b/contracts/47_array_passer.sol
@@ -1,38 +1,49 @@
-import "mortal";
+pragma solidity ^0.4.22;
+
+contract Mortal {
+  /* Define variable owner of the type address */
+  address owner;
+
+  /* This constructor is executed at initialization and sets the owner of the contract */
+  constructor() public { owner = msg.sender; }
+
+  /* Function to recover the funds on the contract */
+  function kill() public { if (msg.sender == owner) selfdestruct(msg.sender); }
+}
 
 // contract Descriptor {
-    
-// 	function getDescription() constant returns (uint16[3]){	
+
+// 	function getDescription() constant returns (uint16[3]){
 // 		uint16[3] somevar;
 // 		return somevar;
 // 	}
 // }
 
-contract ArrayPasser is mortal {
+contract ArrayPasser is Mortal {
 
     address creator;
-    
+
     /***
      * 1. Declare a 3x3 map of Tiles
      ***/
     uint8 mapsize = 3;
-    Tile[3][3] tiles; 
+    Tile[3][3] tiles;
 
-    struct Tile 
+    struct Tile
     {
         /***
-         * 2. A tile is comprised of the owner, elevation and a pointer to a 
+         * 2. A tile is comprised of the owner, elevation and a pointer to a
          *      contract that explains what the tile looks like
          ****/
         uint8 elevation;
         //Descriptor descriptor;
     }
-    
+
     /***
      * 3. Upon construction, initialize the internal map elevations.
      *      The Descriptors start uninitialized.
      ***/
-    function ArrayPasser(uint8[9] incmap) 
+    function ArrayPasser(uint8[9] incmap)
     {
         creator = msg.sender;
         uint8 counter = 0;
@@ -40,12 +51,12 @@ contract ArrayPasser is mortal {
        	{
            	for(uint8 x = 0; x < mapsize; x++)
            	{
-           		tiles[x][y].elevation = incmap[counter]; 
+           		tiles[x][y].elevation = incmap[counter];
            		counter = counter + 1;
-           	}	
-        }	
+           	}
+        }
     }
-   
+
     /***
      * 4. After contract mined, check the map elevations
      ***/
@@ -56,9 +67,9 @@ contract ArrayPasser is mortal {
         {
         	for(uint8 x = 0; x < mapsize; x++)
         	{
-        		elevations[x][y] = tiles[x][y].elevation; 
-        	}	
-        }	
+        		elevations[x][y] = tiles[x][y].elevation;
+        	}
+        }
     	return elevations;
     }
 }

--- a/contracts/48_msg_value_to_bytes20.sol
+++ b/contracts/48_msg_value_to_bytes20.sol
@@ -1,48 +1,56 @@
-import "mortal";
+pragma solidity ^0.4.22;
 
-contract MsgValueToBytes20 is mortal {
+contract Mortal {
+  /* Define variable owner of the type address */
+  address owner;
+
+  /* This constructor is executed at initialization and sets the owner of the contract */
+  constructor() public { owner = msg.sender; }
+
+  /* Function to recover the funds on the contract */
+  function kill() public { if (msg.sender == owner) selfdestruct(msg.sender); }
+}
+
+contract MsgValueToBytes20 is Mortal {
 
 	uint initialval;
-	uint80 uint80val; 
+	uint80 uint80val;
 	bytes20 finalval;
-    
-    function convertMsgValueToBytes20() 
-    {
-    	initialval = msg.value;
-    	if(msg.value > 0 || msg.value < 1208925819614629174706176) // 1 wei up to (2^80 - 1) wei is the valid uint80 range
-    	{
-    		uint80val = uint80(msg.value);
-    		finalval = bytes20(uint80val);
-    	}
-    }
-    
-    function getInitialval() constant returns (uint)
-    {
-    	return initialval;
-    }
-    
-    function getUint80val() constant returns (uint80)
-    {
-    	return uint80val;
-    }
-    
-    function getFinalval() constant returns (bytes20)
-    {
-    	return finalval;
-    }
-    
+
+  function convertMsgValueToBytes20() {
+  	initialval = msg.value;
+
+		// 1 wei up to (2^80 - 1) wei is the valid uint80 range
+  	if (msg.value > 0 || msg.value < 1208925819614629174706176) {
+  		uint80val = uint80(msg.value);
+  		finalval = bytes20(uint80val);
+  	}
+  }
+
+  function getInitialval() constant returns (uint) {
+  	return initialval;
+  }
+
+  function getUint80val() constant returns (uint80) {
+  	return uint80val;
+  }
+
+  function getFinalval() constant returns (bytes20) {
+  	return finalval;
+  }
+
 }
 
 
 /*
+	DEMO:
 
-msgvaluetobytes20.convertMsgValueToBytes20.sendTransaction({from:eth.coinbase,value:web3.toWei(.001,"ether")});
-
-> msgvaluetobytes20.getInitialval();
-10000
-> msgvaluetobytes20.getUint80val();
-10000
-> msgvaluetobytes20.getFinalval();
-"0x0000000000000000000000000000000000002710"
+	> msgvaluetobytes20.convertMsgValueToBytes20.sendTransaction({from:eth.coinbase,value:web3.toWei(.001,"ether")});
+	> msgvaluetobytes20.getInitialval();
+	10000
+	> msgvaluetobytes20.getUint80val();
+	10000
+	> msgvaluetobytes20.getFinalval();
+	"0x0000000000000000000000000000000000002710"
 
 */


### PR DESCRIPTION
Several contracts import 'mortal'. In order to test contracts with
remix and copy paste the file, we replace the import by a contract
declaration.

Minor style suggestions are included
- remove whitespace at EOL
- set tabulation to 2 spaces
- space after 'if' and 'for'

closes #11